### PR TITLE
[Style] 카테고리 스타일 변경(#68)

### DIFF
--- a/src/components/aside/FileMenu/FileMenu.css
+++ b/src/components/aside/FileMenu/FileMenu.css
@@ -30,6 +30,23 @@
 .category-item.active{
     color: #fff;
 }
+.category-name {
+    padding: 8px 0;
+    border-bottom: 1px solid #1C3C5D;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.category-item:last-child .category-name {
+    border-bottom: none;
+}
+.category-check-icon {
+    margin-right: 5px;
+    visibility: hidden;
+}
+.category-item.active .category-check-icon {
+    visibility: visible;
+}
 .add-file-wrapper.active{
     background-color: #465F7A;
     border-radius: 10px;

--- a/src/components/aside/FileMenu/FileMenu.jsx
+++ b/src/components/aside/FileMenu/FileMenu.jsx
@@ -93,8 +93,12 @@ const FileMenu = () => {
                             className={`category-item ${selectedCategoryIdStore === category.id ? 'active' : ''}`}
                             onClick={() => setSelectedCategoryIdStore(category.id)}
                         >
-                            {category.name}
-                            {selectedCategoryIdStore === category.id && <img src={categoryCheckIcon} className="category-check-icon" alt="" />}
+                            <img
+                                src={categoryCheckIcon}
+                                className="category-check-icon"
+                                alt="category-check-icon"
+                            />
+                            <span className="category-name">{category.name}</span>
                         </li>
                     ))}
                 </ul>

--- a/src/components/aside/WritingMenu/WritingMenu.css
+++ b/src/components/aside/WritingMenu/WritingMenu.css
@@ -93,6 +93,13 @@
   width: 18px;
   height: 18px;
   cursor: pointer;
+  border: 1px solid #193553;
+}
+.aside-writing-items > li.active .delete-writing {
+  border: 1px solid #465F7A;
+}
+.aside-writing-items > li.active .delete-writing:hover {
+  border: 1px solid #FFF;
 }
 .delete-writing:hover {
   border: 1px solid #FFF;


### PR DESCRIPTION
- 중간에 선 추가, 앞에 체크 아이콘와 내용 분리
- category-name에서 text-overflow: ellipsis 추가

close #68 

<img width="262" alt="image" src="https://github.com/user-attachments/assets/f5e2260c-50f1-4c74-b49b-431c6d9ab37e">
