### PR TITLE
[Style] 카테고리 스타일 변경(#68)

### DIFF
--- a/src/components/Aside/FileMenu/FileMenu.css
+++ b/src/components/Aside/FileMenu/FileMenu.css
@@ -30,6 +30,23 @@
 .category-item.active{
     color: #fff;
 }
+.category-name {
+    padding: 8px 0;
+    border-bottom: 1px solid #1C3C5D;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.category-item:last-child .category-name {
+    border-bottom: none;
+}
+.category-check-icon {
+    margin-right: 5px;
+    visibility: hidden;
+}
+.category-item.active .category-check-icon {
+    visibility: visible;
+}
 .add-file-wrapper.active{
     background-color: #465F7A;
     border-radius: 10px;

--- a/src/components/Aside/FileMenu/FileMenu.css
+++ b/src/components/Aside/FileMenu/FileMenu.css
@@ -47,6 +47,16 @@
 .category-item.active .category-check-icon {
     visibility: visible;
 }
+.category-item:last-child .category-name {
+    border-bottom: none;
+}
+.category-check-icon {
+    margin-right: 5px;
+    visibility: hidden;
+}
+.category-item.active .category-check-icon {
+    visibility: visible;
+}
 .add-file-wrapper.active{
     background-color: #465F7A;
     border-radius: 10px;

--- a/src/components/Aside/FileMenu/FileMenu.jsx
+++ b/src/components/Aside/FileMenu/FileMenu.jsx
@@ -93,8 +93,12 @@ const FileMenu = () => {
                             className={`category-item ${selectedCategoryIdStore === category.id ? 'active' : ''}`}
                             onClick={() => setSelectedCategoryIdStore(category.id)}
                         >
-                            {category.name}
-                            {selectedCategoryIdStore === category.id && <img src={categoryCheckIcon} className="category-check-icon" alt="" />}
+                            <img
+                                src={categoryCheckIcon}
+                                className="category-check-icon"
+                                alt="category-check-icon"
+                            />
+                            <span className="category-name">{category.name}</span>
                         </li>
                     ))}
                 </ul>


### PR DESCRIPTION
- 중간에 선 추가, 앞에 체크 아이콘와 내용 분리
- category-name에서 text-overflow: ellipsis 추가

close #68 
![image](https://github.com/user-attachments/assets/fda5c18e-08e1-49a0-a84f-5f5bc950c28f)
