### PR TITLE
[Style] word-break 추가, textarea의 전체 내용이 표시 안 된 버그 해결(#76)

### DIFF
--- a/src/components/Aside/FileMenu/FileMenu.css
+++ b/src/components/Aside/FileMenu/FileMenu.css
@@ -1,3 +1,10 @@
+.file-menu-container {
+    height: 90dvh;
+    overflow-y: scroll;
+}
+.file-menu-container::-webkit-scrollbar {
+    display: none;
+}
 /*category-wrapper*/
 .category-wrapper {
     background-color: #152A41;

--- a/src/components/Aside/FileMenu/FileMenu.jsx
+++ b/src/components/Aside/FileMenu/FileMenu.jsx
@@ -79,7 +79,7 @@ const FileMenu = () => {
     }, [cookies.accessToken]);
 
     return (
-        <main>
+        <main className='file-menu-container'>
             <LoadingModal show={getCategoryLoading} />
             <LoadingModal show={categoryLoading} />
             <LoadingModal show={fileAddLoading} />

--- a/src/components/Aside/FileMenu/components/CategoryManageWrapper/CategoryManageWrapper.css
+++ b/src/components/Aside/FileMenu/components/CategoryManageWrapper/CategoryManageWrapper.css
@@ -105,3 +105,6 @@
 #new-category-input::-webkit-scrollbar {
     display: none;
 }
+.category-manage-name {
+    word-break: break-all;
+}

--- a/src/components/Aside/FileMenu/components/CategoryManageWrapper/CategoryManageWrapper.jsx
+++ b/src/components/Aside/FileMenu/components/CategoryManageWrapper/CategoryManageWrapper.jsx
@@ -40,7 +40,7 @@ const CategoryManageWrapper = () => {
                                         }}
                                     />
                                 ) : (
-                                    <div>{category.name}</div>
+                                    <div className='category-manage-name'>{category.name}</div>
                                 )}
                             </td>
                             <td>

--- a/src/components/Aside/FileMenu/components/ModifyFileWrapper/ModifyFileWrapper.css
+++ b/src/components/Aside/FileMenu/components/ModifyFileWrapper/ModifyFileWrapper.css
@@ -60,6 +60,7 @@
     width: fit-content;
     margin-left: 6px;
     margin-bottom: 6px;
+    word-break: break-all;
 }
 .category-modify-option-item.active{
     background-color: #465F7A;

--- a/src/components/Aside/WritingMenu/WritingMenu.css
+++ b/src/components/Aside/WritingMenu/WritingMenu.css
@@ -14,6 +14,7 @@
   margin: 0;
   list-style: none;
   font-size: 14px;
+  word-break: break-all;
 }
 
 .aside-writing-items > li {

--- a/src/components/Aside/WritingMenu/WritingMenu.jsx
+++ b/src/components/Aside/WritingMenu/WritingMenu.jsx
@@ -88,7 +88,7 @@ function WritingMenu() {
                           {currentWritingId === item.id ? (
                             isModifyVisible === item.id ? (
                               <img src={reduceIcon} 
-                                alt="extend" 
+                                alt="delete" 
                                 className='delete-writing'
                                 onClick={(e) => {
                                   e.stopPropagation();
@@ -97,11 +97,12 @@ function WritingMenu() {
                               />
                               ) : (
                               <img src={extendIcon} 
-                                alt="delete" 
+                                alt="extend" 
                                 className='delete-writing'
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setIsModifyVisible(item.id);
+                                  setOnCreate(false);
                                 }}
                               />
                             )
@@ -131,7 +132,13 @@ function WritingMenu() {
             {onCreate ? (
               <NewWriting initialData={null} onClose={()=> setOnCreate(false)}/>
             ):
-            <button className="aside-writing-create-btn" onClick={() => { setOnCreate(true) }}>
+            <button
+              className="aside-writing-create-btn" 
+              onClick={() => { 
+                setOnCreate(true);
+                setIsModifyVisible(null);
+              }}
+            >
               + 새로운 글쓰기 추가
             </button>
             }

--- a/src/components/Aside/WritingMenu/hooks/useWritingForm.js
+++ b/src/components/Aside/WritingMenu/hooks/useWritingForm.js
@@ -17,6 +17,12 @@ function useWritingForm(initialData) {
         startDate: { year: start[0], month: start[1], day: start[2] },
         endDate: { year: end[0], month: end[1], day: end[2] }
       });
+      setTimeout(() => {
+        document.querySelectorAll('textarea').forEach(textarea => {
+          textarea.style.height = 'auto';
+          textarea.style.height = textarea.scrollHeight + 'px';
+        });
+      }, 0);
     }
     else{
       setAssignmentData({

--- a/src/components/Aside/WritingMenu/hooks/useWritingForm.js
+++ b/src/components/Aside/WritingMenu/hooks/useWritingForm.js
@@ -17,12 +17,6 @@ function useWritingForm(initialData) {
         startDate: { year: start[0], month: start[1], day: start[2] },
         endDate: { year: end[0], month: end[1], day: end[2] }
       });
-      setTimeout(() => {
-        document.querySelectorAll('textarea').forEach(textarea => {
-          textarea.style.height = 'auto';
-          textarea.style.height = textarea.scrollHeight + 'px';
-        });
-      }, 0);
     }
     else{
       setAssignmentData({
@@ -36,6 +30,13 @@ function useWritingForm(initialData) {
       });
     }
   }, [initialData]);
+
+  useEffect(() => {
+    document.querySelectorAll('textarea').forEach(textarea => {
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+    });
+  }, [assignmentData]);
 
   const handleTitleChange = (e) => {
     handleTextareaChange(e);


### PR DESCRIPTION
1. word-break 추가하고 나서 긴 내용이 이렇게 나옵니다
<img width="253" alt="image" src="https://github.com/user-attachments/assets/f938c59c-5538-45fc-85e3-88b27f802030">
<img width="256" alt="image" src="https://github.com/user-attachments/assets/53bc1ed0-bb41-4e7a-b274-adff84db4cbc">
<img width="256" alt="image" src="https://github.com/user-attachments/assets/1f0b556b-05e4-4e72-acc4-b0ab21f15871">

2. 과제 생성나 수정할 때 공동 NewWriting 컴포넌트를 사용해서 생성 버튼을 클릭하면 열려 있는 수정 영역이 닫히도록, 수정 버튼을 클릭하면 열려 있는 생성 영역이 닫히도록 했다

3.  과제 수정할 때 textarea가 전체 내용이 표시 안되고 첫줄만 표시돼요. 
- 테스크가 변경되어야 handleTextareaChange 함수가 실행되므로 첫번째 렌더링할 때  테스크 변경이 없어서 textarea의 height가 auto로 바뀌지 않은 것 같아요
- min-height 추가해봤는데 해결 안 되요
- 그래서  초기화할 때 useEffect에서 setTimeout(0) 안에  textarea의 height를 auto로 설정했어요.
- 더 좋은 방법이 있으면 말해주세요 ㅠㅠ

소스코드: src/components/Aside/WritingMenu/hooks/useWritingForm.js:20부터 봐주세요 ㅠ
<img width="266" alt="image" src="https://github.com/user-attachments/assets/5d8a0518-dc6b-41c0-84d1-443bb256063a">

4. FileMenu에서 scroll 추가
close #76 