### PR TITLE
피드백 테스팅 페이지 구현(#84)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Chatbot from './routes/Chatbot/Chatbot';
 import ChatStu from './routes/ChatStu/ChatStu';
 import WritingSubmit from './routes/WritingSubmit/WritingSubmit';
 import File from './routes/File/File';
+import Testing from './routes/Testing/Testing';
 
 function App() {
   const showAside = useShowAside();
@@ -37,6 +38,7 @@ function App() {
         <Route path='/manage' element={<Manage />} />
         <Route path='/manage/:id' element={<History />} />
         <Route path="/redirect/:option" element={<Redirect />} />
+        <Route path="/writing/testing" element={<Testing />} />
       </Routes>
     </div>
   )

--- a/src/assets/icons/left-arrow.svg
+++ b/src/assets/icons/left-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 15L12 10L8 5" stroke="black"/>
+</svg>

--- a/src/components/Aside/WritingMenu/WritingMenu.css
+++ b/src/components/Aside/WritingMenu/WritingMenu.css
@@ -94,7 +94,15 @@
 .aside-writing::-webkit-scrollbar {
   display: none;
 }
-
+.testing-item{
+  background: linear-gradient(97.49deg, #465F7A 5.21%, #7D71BC 48.2%, #81AEE0 112.33%);
+  border-radius: 10px;
+  padding: 12px;
+  color: white;
+  font-size: 14px;
+  margin-bottom: 4px;
+  cursor: pointer;
+}
 @media screen and (max-width: 900px) {
   .aside-writing {
     padding: 0;

--- a/src/components/Aside/WritingMenu/WritingMenu.jsx
+++ b/src/components/Aside/WritingMenu/WritingMenu.jsx
@@ -55,6 +55,12 @@ function WritingMenu() {
       </div>
       {isMenuVisible && (
         <article className='aside-writing-content'>
+            <div 
+              className='testing-item' 
+              onClick={()=>{navigate('/writing/testing')}}
+            >
+              피드백 테스트
+            </div>
             <ul className="aside-writing-items">
               {
                 writingList.map((item, i) => {

--- a/src/routes/Testing/Testing.css
+++ b/src/routes/Testing/Testing.css
@@ -1,0 +1,120 @@
+.testing-main {
+  padding-left: 280px;
+  height: 100dvh;
+  width: 100%;
+  font-size: 14px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+.testing-header {
+  width: 100%;
+  background-color: #4f6b8a;
+  padding: 10px;
+  box-sizing: border-box;
+}
+.testing-header span {
+  color: #fff;
+  font-size: 16px;
+  margin-left: 380px;
+}
+.testing-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  flex: 1;
+  padding: 40px 100px 40px calc(280px + 100px);
+}
+.testing-btn {
+  background-color: #001832;
+  color: #fff;
+  font-size: 14px;
+  border-radius: 10px;
+  padding: 8px 10px;
+  border: none;
+  cursor: pointer;
+  align-self: flex-end;
+}
+.constraints-container {
+  background-color: #f0f1f3;
+  padding: 14px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 12px;
+}
+.constraints-container > div {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.content-container {
+  border-top: 1px solid #e6e8eb;
+  border-bottom: 1px solid #e6e8eb;
+  flex: 1;
+}
+.content-container {
+  display: flex;
+  flex-direction: row;
+}
+.label {
+  font-size: 14px;
+  color: #000;
+  font-weight: 400;
+  background-color: #f0f1f3;
+  padding: 4px 8px;
+  border-radius: 10px;
+}
+.writing-wrapper,
+.feedback-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+}
+hr {
+  border: 1px solid #f0f1f3;
+  margin: 0;
+}
+#constraints-content {
+  border: none;
+  resize: none;
+  word-break: keep-all;
+  background-color: #f0f1f3;
+  flex-grow: 1;
+}
+#constraints-content:focus {
+  outline: none;
+}
+#writing-content {
+  border: none;
+  resize: none;
+  word-break: keep-all;
+  flex-grow: 1;
+}
+#writing-content:focus {
+  outline: none;
+}
+
+@media screen and (max-width: 900px) {
+  .testing-main {
+    padding-left: 0;
+  }
+  .testing-header{
+    display: none;
+  }
+  .testing-content {
+    padding: 20px;
+    padding-top: 70px;
+  }
+  .content-container {
+    flex-direction: column;
+    display: block;
+    height: 100%;
+  }
+  .writing-wrapper{
+    height: 50%;
+  }
+}

--- a/src/routes/Testing/Testing.jsx
+++ b/src/routes/Testing/Testing.jsx
@@ -1,0 +1,67 @@
+import "./Testing.css";
+import leftArrow from "../../assets/icons/left-arrow.svg";
+import useTesting from "./hooks/useTesting";
+
+function Testing() {
+  const { 
+    constraintsRef, 
+    writingRef,
+    writingContent,
+    handleWritingChange,
+    constraintsContent,
+    handleConstraintsChange,
+    feedbackContent,
+    getFeedback,
+  } = useTesting();
+
+  return (
+    <main className="testing-main">
+      <header className="testing-header">
+        <span>피드백 테스트</span>
+      </header>
+      <section className="testing-content">
+        <button className="testing-btn" onClick={getFeedback}>
+          테스트 시작
+        </button>
+        <article className="constraints-container">
+          <div>
+            <img src={leftArrow} alt="left-arrow" />
+            <span>규정 입력하기</span>
+          </div>
+          <textarea
+            name="constraints-content"
+            id="constraints-content"
+            rows={1}
+            ref={constraintsRef}
+            value={constraintsContent}
+            onChange={handleConstraintsChange}
+          />
+        </article>
+        <article className="content-container">
+          <div className="writing-wrapper">
+            <div>
+              <span className="label">나의 글</span>
+            </div>
+            <textarea
+              name="writing-content"
+              id="writing-content"
+              rows={1}
+              ref={writingRef}
+              value={writingContent}
+              onChange={handleWritingChange}
+            />
+          </div>
+          <hr />
+          <div className="feedback-wrapper">
+            <div>
+              <span className="label">피드백</span>
+            </div>
+            <p className="feedback-content">{feedbackContent}</p>
+          </div>
+        </article>
+      </section>
+    </main>
+  );
+}
+
+export default Testing;

--- a/src/routes/Testing/hooks/useTesting.js
+++ b/src/routes/Testing/hooks/useTesting.js
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+import { handleTextareaChange } from "../../../utils/textareaHandler";
+
+function useTesting() {
+  const constraintsRef = useRef();
+  const writingRef = useRef();
+  const [constraintsContent, setConstraintsContent] = useState("");
+  const [writingContent, setWritingContent] = useState("");
+  const [feedbackContent, setFeedbackContent] = useState(""); 
+
+  useEffect(() => {
+    if (constraintsRef.current) {
+      handleTextareaChange({ currentTarget: constraintsRef.current });
+    }
+  }, [constraintsContent]);
+
+  useEffect(() => {
+    if (writingRef.current) {
+      handleTextareaChange({ currentTarget: writingRef.current });
+    }
+  }, [writingContent]);
+
+  const handleConstraintsChange = (e) => {
+    setConstraintsContent(e.target.value);
+  };
+
+  const handleWritingChange = (e) => {
+    setWritingContent(e.target.value);
+  };
+
+  const getFeedback = () => {
+    // api
+    setFeedbackContent("피드백 내용");
+  }
+
+  return { 
+    constraintsRef, 
+    writingRef,
+    writingContent,
+    handleWritingChange,
+    constraintsContent,
+    handleConstraintsChange,
+    feedbackContent,
+    getFeedback,
+  };
+}
+
+export default useTesting;


### PR DESCRIPTION
- WritingMenu에다가 피드백 테스트 메뉴 생성
- 그 메뉴를 클릭하면 테스팅 페이지로 navigate
- 테스팅 페이지 레이아웃 구현
- textarea 입력 처리를 hook에서 구현 했음
- getFeedback 함수: api 호출하여 피드백 내용을 받도록 한다 (미구현)
- 모바일 스타일 구현

Relate #84 
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/cc8a16df-0134-4b46-8fe2-758ac4b06388">
<img width="499" alt="image" src="https://github.com/user-attachments/assets/3af98c55-7164-4ee3-8743-bd73a4179bab">
